### PR TITLE
Create `.swiftenv` folder on first invoke

### DIFF
--- a/libexec/swiftenv
+++ b/libexec/swiftenv
@@ -5,6 +5,9 @@ set -e
 if [ -z "$SWIFTENV_ROOT" ]; then
   SWIFTENV_ROOT=$HOME/.swiftenv
 fi
+if [ ! -d "$SWIFTENV_ROOT" ]; then
+  mkdir "$SWIFTENV_ROOT"
+fi
 export SWIFTENV_ROOT
 
 find_libexec_path() {


### PR DESCRIPTION
Fixes

```
/usr/local/Cellar/swiftenv/0.2.0/bin/../libexec/swiftenv-global: line 22: /Users/mkida/.swiftenv/version: No such file or directory
```

When trying to set global version without creating `~/.swiftenv` prior to first use.