### PR TITLE
Whitelist swift and lldb shims during rehash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- Only create shims for `swift*` and `lldb*` binaries found within Xcode
+  installs. Before we created shims for all executable tools found in Xcode
+  and created shims for tools like ctags, cc, clang, etc.
+
+
 ## 1.1.0
 
 ### Enhancements

--- a/libexec/swiftenv-rehash
+++ b/libexec/swiftenv-rehash
@@ -28,7 +28,10 @@ list_executable_names_xcodes() {
       TOOLCHAIN_DIR="$xcode/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"
       if [ -d "$TOOLCHAIN_DIR" ]; then
         for file in "$TOOLCHAIN_DIR/usr/bin/"*; do
-          echo "${file##*/}"
+          executable="${file##*/}"
+          if [[ "$executable" == "swift"* ]] || [[ "$executable" == "lldb"* ]]; then
+            echo "$executable"
+          fi
         done
       fi
     done


### PR DESCRIPTION
This pull request changes how rehash works. Previously we created a shim for all executables found in a Swift version, toolchain or Xcode release. We will now only create shims which match swift* or lldb*.

I'm concerned that this may break some other tools where they are expecting some executables which may differ per swift (not sure if there are any).

