### PR TITLE
Support for swift 3.0 GM candidate on Linux

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -233,6 +233,10 @@ elif [[ "$VERSION" == *"-SNAPSHOT-"* ]]; then
 elif [[ "$VERSION" == *"-PREVIEW-"* ]]; then
   RELEASE="swift-$(echo $VERSION | sed 's/PREVIEW/preview/')"
   VERSION_BINARY="$VERSION"
+elif [[ "$VERSION" == *"-GM-CANDIDATE" ]]; then
+  VERSION_NUMBER=${VERSION%%-GM-CANDIDATE}
+  RELEASE="swift-$VERSION_NUMBER-GM"
+  VERSION_BINARY="$VERSION"
 else
   RELEASE="swift-$VERSION-release"
   VERSION_BINARY="$VERSION-RELEASE"


### PR DESCRIPTION
I couldn't get it to work on osx because https://swiftenv-api.fuller.li/versions/3.0-GM-CANDIDATE/binaries/osx doesn't return a URL but it works on linux.