### PR TITLE
updating swiftenv-install to support latest 3.0 version for linux (a.k.a 3.0-RELEASE)

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -238,8 +238,13 @@ elif [[ "$VERSION" == *"-GM-CANDIDATE" ]]; then
   RELEASE="swift-$VERSION_NUMBER-GM-CANDIDATE"
   VERSION_BINARY="$VERSION"
 else
-  RELEASE="swift-$VERSION-release"
-  VERSION_BINARY="$VERSION-RELEASE"
+  if [[ "$VERSION" == *"-RELEASE" ]]; then
+    RELEASE="swift-$VERSION"
+    VERSION_BINARY="$VERSION"
+  else
+    RELEASE="swift-$VERSION-release"
+    VERSION_BINARY="$VERSION-RELEASE"
+  fi
 fi
 
 if [ "$build" == "auto" ]; then


### PR DESCRIPTION
I tried to use swiftenv to install swift version 3.0 in ubuntu14.04. The url is the following one:

https://swift.org/builds/swift-3.0-release/ubuntu1404/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu14.04.tar.gz

VERSION matches to 3.0-RELEASE
and therefore VERSION_BINARY goes to 3.0-RELEASE-RELEASE

I was getting this error when installing:
`mv: cannot stat ‘/tmp/swiftenv-3.0-RELEASE/swift-3.0-RELEASE-RELEASE*’: No such file or directory`

I just updated swiftenv-install to consider the case where RELEASE is postponed at the end of the version.