### PR TITLE
Add "--verify" option for installations.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,6 +87,14 @@ information.
 **NOTE**: *After manually installing a version of Swift, it's recommended that
 you run `swiftenv rehash` to update the shims.*
 
+### Verifying Linux Binary Packages
+
+When downloading a pre-built binary package, swiftenv can also download the corresponding signature and verify it with gpg. This option assumes gpg is installed on the system, and the [Swift public keys](https://swift.org/download/#active-signing-keys) already exist on the public gpg keyring. If verification fails, the version will not be installed. Signatures are currently only checked in this way for Linux builds.
+
+```shell
+$ swiftenv install 2.2 --verify
+```
+
 ## `uninstall`
 
 Uninstalls a specific Swift version.

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -82,7 +82,7 @@ install_tar_binary() {
 
   echo "Downloading $URL"
 
-  if $verfiy; then
+  if $verify; then
     pushd "$TMPDIR/swiftenv-$VERSION"
     curl -O "$URL"
     curl -O "$URL.sig"

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -83,9 +83,6 @@ install_tar_binary() {
   echo "Downloading $URL"
 
   if $verfiy; then
-    echo $VERSION_RELEASE
-    echo $VERSION
-
     pushd "$TMPDIR/swiftenv-$VERSION"
     curl -O "$URL"
     curl -O "$URL.sig"

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -81,7 +81,20 @@ install_tar_binary() {
   mkdir -p "$TMPDIR/swiftenv-$VERSION"
 
   echo "Downloading $URL"
-  curl "$URL" -s | tar xz -C "$TMPDIR/swiftenv-$VERSION"
+
+  if $verfiy; then
+    echo $VERSION_RELEASE
+    echo $VERSION
+
+    pushd "$TMPDIR/swiftenv-$VERSION"
+    curl -O "$URL"
+    curl -O "$URL.sig"
+    gpg --verify "swift-$VERSION"*.sig
+    tar xzf "swift-$VERSION"*.tar.gz
+    popd
+  else
+    curl "$URL" -s | tar xz -C "$TMPDIR/swiftenv-$VERSION"
+  fi
 
   DESTINATION="$SWIFTENV_ROOT/versions/$VERSION"
   mv "$TMPDIR/swiftenv-$VERSION/swift-$VERSION_RELEASE"* "$DESTINATION"
@@ -151,6 +164,7 @@ list=false
 snapshots=false
 build=auto
 verbose=false
+verify=false
 
 unset SKIP_EXISTING
 
@@ -174,6 +188,8 @@ for args in "$@"; do
     SKIP_EXISTING=true
   elif [ "$args" = "--verbose" ]; then
     verbose=true
+  elif [ "$args" = "--verify" ]; then
+    verify=true
   else
     VERSION="$args"
   fi

--- a/share/man/man1/swiftenv-install.1
+++ b/share/man/man1/swiftenv-install.1
@@ -47,3 +47,9 @@ Forces installation only from binary releases of Swift.
 .RS
 Leaves the build directory intact for inspection and debugging.
 .RE
+
+\-\-verify\
+
+.RS
+When downloading a pre-packaged tarball, also downloads the corresponding signature and verifies it with gpg. Assumes the keys already exist on the public gpg keyring. If verification fails, the version will not be installed. Signatures are only published for Linux tarballs, and not macOS packages.
+.RE

--- a/share/swiftenv-install/3.0.1
+++ b/share/swiftenv-install/3.0.1
@@ -1,0 +1,20 @@
+case "$PLATFORM" in
+  'ubuntu14.04' )
+    URL="https://swift.org/builds/swift-3.0.1-release/ubuntu1404/swift-3.0.1-RELEASE/swift-3.0.1-RELEASE-ubuntu14.04.tar.gz"
+    ;;
+
+  'ubuntu15.10' )
+    URL="https://swift.org/builds/swift-3.0.1-release/ubuntu1510/swift-3.0.1-RELEASE/swift-3.0.1-RELEASE-ubuntu15.10.tar.gz"
+    ;;
+
+  'ubuntu16.04' )
+    URL="https://swift.org/builds/swift-3.0.1-release/ubuntu1604/swift-3.0.1-RELEASE/swift-3.0.1-RELEASE-ubuntu16.04.tar.gz"
+    ;;
+
+  'osx' )
+    URL="https://swift.org/builds/swift-3.0.1-release/xcode/swift-3.0.1-RELEASE/swift-3.0.1-RELEASE-osx.pkg"
+    ;;
+
+  * )
+    ;;
+esac


### PR DESCRIPTION
As requested in #64. The install command now accepts a verify option that will download and check the gpg signature. For security, we do not automatically install any keys during the swift installation step, and instead assume (with documentation) that they have been installed by the user out-of-band.

```bash
$ swift install 2.2 --verify
```