### PR TITLE
Remove dot command, improve fishconfig addition

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,7 +35,7 @@
     ```shell
     $ echo 'setenv SWIFTENV_ROOT "$HOME/.swiftenv"' >> ~/.config/fish/config.fish
     $ echo 'setenv PATH "$SWIFTENV_ROOT/bin" $PATH' >> ~/.config/fish/config.fish
-    $ echo 'status --is-interactive; and . (swiftenv init -|psub)' >> ~/.config/fish/config.fish
+    $ echo 'if which swiftenv > /dev/null; status --is-interactive; and source (swiftenv init -|psub); end' >> ~/.config/fish/config.fish
     ```
 
     For other shells, please [open an issue](https://github.com/kylef/swiftenv/issues/new) and we will visit adding support.
@@ -72,7 +72,7 @@ on macOS.
     For Fish:
 
     ```shell
-    $ echo 'status --is-interactive; and . (swiftenv init -|psub)' >> ~/.config/fish/config.fish
+    $ echo 'if which swiftenv > /dev/null; status --is-interactive; and source (swiftenv init -|psub); end' >> ~/.config/fish/config.fish
     ```
 
 ## Uninstalling swiftenv


### PR DESCRIPTION
Using `.` in fish is deprecated:

https://fishshell.com/docs/current/commands.html#source

> . (a single period) is an alias for the source command. The use of . is deprecated in favour of source, and . will be removed in a future version of fish.