### PR TITLE
Allow configuring when global/local is set during `swiftenv install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Master
+
+### Enhancements
+
+- You can now instruct `swiftenv install` to both locally and globally set the
+  installed swift version. `--set-local` and `--set-global` respectively will
+  set the current Swift version.
+
+  The default behaviour will set the global version by default when `swiftenv
+  install` was provided an explicit version. When installing with the
+  `SWIFT_VERSION` environment value or the `.swift-version` file present, then
+  the default behaviour is to not set the global or local version.
+
 ## 1.3.0
 
 ### Enhancements

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -15,10 +15,23 @@ check_installed() {
     echo "$VERSION is already installed."
 
     if [ -n "$SKIP_EXISTING" ]; then
+      update_version_files
       exit 0
     fi
 
     exit 1
+  fi
+}
+
+update_version_files() {
+  if ([ "$set_global" == "auto" ] && [ "$set_local" == "false" ]); then
+    swiftenv-global "$VERSION"
+  elif ([ "$set_global" == "true" ]); then
+    swiftenv-global "$VERSION"
+  fi
+
+  if [ "$set_local" == "true" ]; then
+    swiftenv-local "$VERSION"
   fi
 }
 
@@ -181,6 +194,8 @@ snapshots=false
 build=auto
 verbose=false
 verify=false
+set_global=auto
+set_local=false
 
 if [ -n "$SWIFTENV_VERIFY" ] && [ "$SWIFTENV_VERIFY" != "false" ]; then
   verify=true
@@ -212,6 +227,14 @@ for args in "$@"; do
     verify=true
   elif [ "$args" = "--no-verify" ]; then
     verify=false
+  elif [ "$args" = "--no-set-global" ]; then
+    set_global=false
+  elif [ "$args" = "--no-set-local" ]; then
+    set_local=false
+  elif [ "$args" = "--set-global" ]; then
+    set_global=true
+  elif [ "$args" = "--set-local" ]; then
+    set_local=true
   else
     VERSION="$args"
   fi
@@ -238,6 +261,10 @@ fi
 mkdir -p "$SWIFTENV_ROOT/versions"
 if [ -z "$VERSION" ] ; then
   VERSION="$(swiftenv-version-name --dont-check)"
+
+  if [ "$set_global" == "auto" ]; then
+    set_global=false
+  fi
 
   if [ "$VERSION" == "system" ]; then
     echo "Usage: swiftenv install <version>"
@@ -292,4 +319,5 @@ fi
 
 echo "$VERSION has been installed."
 swiftenv-rehash
-swiftenv-global "$VERSION"
+
+update_version_files

--- a/share/man/man1/swiftenv-install.1
+++ b/share/man/man1/swiftenv-install.1
@@ -4,7 +4,7 @@
 swiftenv-install \- Install a version of Swift
 
 .SH SYNOPSIS
-swiftenv install [\-\-verbose] [\-\-list] [\-\-list-snapshots] [\-\-[no\-]build] [--no-clean] <version>
+swiftenv install [\-\-verbose] [\-\-list] [\-\-list-snapshots] [\-\-[no\-]build] [\-\-[no\-]set\-global] [\-\-[no\-]set\-local] [--no-clean] <version>
 
 .SH DESCRIPTION
 
@@ -52,4 +52,29 @@ Leaves the build directory intact for inspection and debugging.
 
 .RS
 When downloading a pre-packaged tarball, also downloads the corresponding signature and verifies it with gpg. Assumes the keys already exist on the public gpg keyring. If verification fails, the version will not be installed. Signatures are only published for Linux tarballs, and not macOS packages.
+.RE
+
+\-\-set\-global
+
+.RS
+Set the installed version globally.
+.RE
+
+\-\-no\-set\-global
+
+.RS
+Don't set the installed version globally.
+.RE
+
+\-\-set\-local
+
+.RS
+Set the installed version in the local .swift-version file.
+.RE
+
+
+\-\-no\-set\-local
+
+.RS
+Don't set the installed version locally.
 .RE

--- a/test/install.bats
+++ b/test/install.bats
@@ -37,3 +37,45 @@ load helpers
   [ "${lines[3]}" = "3.0-dev" ]
 }
 
+@test "invoking with an installed version with skip existing saves global version" {
+  mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
+  run swiftenv install -s 1.0.0
+  [ "$status" -eq 0 ]
+  [ "$lines" = "1.0.0 is already installed." ]
+  [ "$(cat $SWIFTENV_ROOT/version)" = "1.0.0" ]
+}
+
+@test "invoking with an installed version with skip existing disable global version" {
+  mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
+  run swiftenv install --no-set-global -s 1.0.0
+  [ "$status" -eq 0 ]
+  [ "$lines" = "1.0.0 is already installed." ]
+  [ ! -r "$SWIFTENV_ROOT/version" ]
+}
+
+@test "invoking with an installed version with skip existing and set local version" {
+  mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
+  run swiftenv install --set-local -s 1.0.0
+  [ "$status" -eq 0 ]
+  [ "$lines" = "1.0.0 is already installed." ]
+  [ ! -r "$SWIFTENV_ROOT/version" ]
+  [ "$(cat .swift-version)" = "1.0.0" ]
+}
+
+@test "invoking with an installed version with skip existing and set global and local version" {
+  mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
+  run swiftenv install --set-local --set-global -s 1.0.0
+  [ "$status" -eq 0 ]
+  [ "$lines" = "1.0.0 is already installed." ]
+  [ "$(cat $SWIFTENV_ROOT/version)" = "1.0.0" ]
+  [ "$(cat .swift-version)" = "1.0.0" ]
+}
+
+@test "invoking with an installed version with local version doesnt set global" {
+  echo '1.0.0' > .swift-version
+  mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
+  run swiftenv install -s
+  [ "$status" -eq 0 ]
+  [ "$lines" = "1.0.0 is already installed." ]
+  [ ! -r "$SWIFTENV_ROOT/version" ]
+}


### PR DESCRIPTION
You can now instruct `swiftenv install` to both locally and globally set the installed swift version. `--set-local` and `--set-global` respectively will set the current Swift version.

The default behaviour will set the global version by default when `swiftenv install` was provided an explicit version. When installing with the `SWIFT_VERSION` environment value or the `.swift-version` file present, then the default behaviour is to not set the global or local version.

Closes #83