### PR TITLE
Add short option to 'install --list'

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -230,7 +230,7 @@ for args in "$@"; do
     clean=false
   elif [ "$args" = "--clean" ]; then
     clean=true
-  elif [ "$args" = "--list" ]; then
+  elif [ "$args" = "--list" ] || [ "$args" = "-l" ];  then
     list=true
   elif [ "$args" = "--list-snapshots" ]; then
     list=true

--- a/share/man/man1/swiftenv-install.1
+++ b/share/man/man1/swiftenv-install.1
@@ -18,7 +18,7 @@ Installs a version of Swift.
 Shows additional debugging information.
 .RE
 
-\-\-list
+\-l/\-\-list
 
 .RS
 Lists all the Swift releases that can be installed.

--- a/test/install.bats
+++ b/test/install.bats
@@ -37,6 +37,15 @@ load helpers
   [ "${lines[3]}" = "3.0-dev" ]
 }
 
+@test "invoking with the -l option as a short option of install --list" {
+  run swiftenv install -l
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "2.2-dev" ]
+  [ "${lines[1]}" = "2.2" ]
+  [ "${lines[2]}" = "2.2.1" ]
+  [ "${lines[3]}" = "3.0-dev" ]
+}
+
 @test "invoking with an installed version with skip existing saves global version" {
   mkdir -p "$SWIFTENV_ROOT/versions/1.0.0"
   run swiftenv install -s 1.0.0


### PR DESCRIPTION
I want `install -l` as a short option of `install --list` in swiftenv. It exists also in pyenv and other implementations.

This option behaves as follows.

```sh
$ swiftenv install -l
2.2-dev
2.2
2.2.1
3.0-dev
3.0
3.0.1
3.0.2
3.1-dev
3.1
3.1.1
4.0-dev
4.0
4.0.2
4.0.3
4.1-dev
4.1
4.2-dev
5.0-dev
```

swiftenv is very useful for me. Thanks to maintenance. 😄 