### PR TITLE
Update dependencies for FreeBSD

### DIFF
--- a/docs/building-swift.md
+++ b/docs/building-swift.md
@@ -75,7 +75,7 @@ $ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3
 You will need to install the following dependencies on FreeBSD:
 
 ```shell
-$ pkg install clang36-3.6.2 git python ninja cmake pkgconf e2fsprogs-lluuid
+$ pkg install binutils git python ninja cmake pkgconf e2fsprogs-libuuid
 ```
 
 ### Your platform here


### PR DESCRIPTION
* The default `clang` that comes with FreeBSD 11 can already compile swift, so there is no need to install it separately. (See related [pull request](https://github.com/apple/swift/pull/169).)
* `e2fsprogs-lluuid` has been renamed to `e2fsprogs-libuuid`.
* When compiling swift the following error occurred:

      clang: error: invalid linker name in argument '-fuse-ld=gold'

  `binutils` supplies the missing linker.