### PR TITLE
Add support for Centos7/8, Amazonlinux2 and aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,3 @@ test-integration: bats
 
 bats:
 	git clone --depth 1 https://github.com/sstephenson/bats.git
-
-CACHED_VERSIONS := \
-  4.1.3 4.2.4 \
-  5.0 5.0.1 5.0.2 5.0.3 \
-  5.1 5.2 5.2.1 5.2.2 5.2.3 \
-  5.3 5.4 5.4.2
-CACHED_PATHS := $(foreach version,$(CACHED_VERSIONS),share/swiftenv-install/$(version))
-versions: $(CACHED_PATHS)
-
-share/swiftenv-install/%:
-	@echo Generating $*
-	@curl -o $@.json https://swiftenv-api.fuller.li/versions/$*
-	@cat $@.json | python -c "import json, sys; p = json.load(sys.stdin)['_links']; p = sorted(['  \'{}\' )\n    URL=\"{}\"\n    ;;\n'.format(p, u['href']) for (p,u) in p.items() if p != 'self']); print('case \"%sPLATFORM\" in') % chr(36); print('\n'.join(p)); print('  * )\n    ;;\nesac')" > $@

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ bats:
 CACHED_VERSIONS := \
   4.1.3 4.2.4 \
   5.0 5.0.1 5.0.2 5.0.3 \
-  5.1 5.2 5.2.1 5.2.2
+  5.1 5.2 5.2.1 5.2.2 5.2.3 \
+  5.3 5.4 5.4.2
 CACHED_PATHS := $(foreach version,$(CACHED_VERSIONS),share/swiftenv-install/$(version))
 versions: $(CACHED_PATHS)
 

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -201,18 +201,22 @@ find_binary_url_from_api() {
     'ubuntu'* )
       SWIFT_BUILD_FOLDER=${platform/.}
       SWIFT_ZIP_FILE=$platform
+      EXTENSION="tar.gz"
       ;;
     'centoslinux'* )
       SWIFT_BUILD_FOLDER=${platform/linux}
       SWIFT_ZIP_FILE=${platform/linux}
+      EXTENSION="tar.gz"
       ;;
     'amazonlinux2')
       SWIFT_BUILD_FOLDER="amazonlinux2"
       SWIFT_ZIP_FILE="amazonlinux2"
+      EXTENSION="tar.gz"
       ;;
     'osx')
-      url="https://swift.org/builds/swift-$VERSION-release/xcode/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-osx.pkg"
-      return
+      SWIFT_BUILD_FOLDER="xcode"
+      SWIFT_ZIP_FILE="osx"
+      EXTENSION="pkg"
       ;;
     *)
       echo "There was a problem identifying your OS $(get_platform)"
@@ -220,7 +224,15 @@ find_binary_url_from_api() {
       ;;
   esac
 
-  url="https://swift.org/builds/swift-$VERSION-release/$SWIFT_BUILD_FOLDER/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$SWIFT_ZIP_FILE.tar.gz"
+  case "$VERSION" in
+    *'-DEVELOPMENT-SNAPSHOT'* )
+      VERSION_NUMBER=$(echo "$VERSION" | cut -d "-" -f1)
+      url="https://swift.org/builds/swift-$VERSION_NUMBER-branch/$SWIFT_BUILD_FOLDER/swift-$VERSION/swift-$VERSION-$SWIFT_ZIP_FILE.$EXTENSION" ;;
+    "DEVELOPMENT-SNAPSHOT"* )
+      url="https://swift.org/builds/development/$SWIFT_BUILD_FOLDER/swift-$VERSION/swift-$VERSION-$SWIFT_ZIP_FILE.$EXTENSION" ;;
+    * )
+      url="https://swift.org/builds/swift-$VERSION-release/$SWIFT_BUILD_FOLDER/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$SWIFT_ZIP_FILE.$EXTENSION"
+  esac
 }
 
 sort_versions() {

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -94,11 +94,6 @@ download() {
   URL=$1
   FILE=$2
   if ! [ -r "$FILE" ]; then
-    status_code=$(curl -I -s -o /dev/null -w "%{http_code}" $URL || true)
-    if [ "$status_code" != "200" ]; then
-      echo "Cannot find file $URL"
-      exit 1
-    fi  
     curl -C - -Lo "$FILE.download" "$URL"
     mv "$FILE.download" "$FILE"
   fi
@@ -408,6 +403,12 @@ if ([ "$build" == "auto" ] || [ "$build" == "false" ]); then
   if [ -z "$url" ]; then
     find_binary_url_from_api
   fi
+
+  # verify URL points to valid file
+  status_code=$(curl -I -s -o /dev/null -w "%{http_code}" $url || true)
+  if [ "$status_code" == "404" ]; then
+    unset url
+  fi  
 
   if [ "$url" ]; then
     install_binary "$VERSION" "$url"

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -35,8 +35,10 @@ update_version_files() {
   fi
 }
 
-get_os_version_variable() {
-  grep "^$1=" /etc/os-release | cut -d "=" -f2 | tr -d '"'
+get_os_version() {
+  test -e /etc/os-release && os_release='/etc/os-release' || os_release='/usr/lib/os-release'
+  . "${os_release}"
+  echo $NAME $VERSION_ID
 }
 
 get_platform() {
@@ -52,9 +54,9 @@ get_platform() {
 
   case $(uname) in
   'Linux' )
-    OS_NAME=$(get_os_version_variable NAME)	  
-    OS_VERSION_ID=$(get_os_version_variable VERSION_ID)
-    echo "$OS_NAME:$OS_VERSION_ID"
+    # lowercase OS_VERSION and remove spaces so get_platform is consistent with previous builds
+    OS_VERSION=$(get_os_version) | tr '[:upper:]' '[:lower:]' | tr -d ' '
+    echo "$OS_VERSION"
     ;;
   'Darwin' )
     echo "osx"
@@ -196,27 +198,31 @@ find_binary_url_from_api() {
   vlog "Checking for a URL for Swift $VERSION on $(get_platform)."
 
   case $(get_platform) in
-    'Ubuntu:16.04' )
+    'ubuntu14.04' )
+      SWIFT_BUILD_FOLDER="ubuntu1604"
+      SWIFT_ZIP_FILE="ubuntu14.04"
+      ;;
+    'ubuntu16.04' )
       SWIFT_BUILD_FOLDER="ubuntu1604"
       SWIFT_ZIP_FILE="ubuntu16.04"
       ;;
-    'Ubuntu:18.04' )
+    'ubuntu18.04' )
       SWIFT_BUILD_FOLDER="ubuntu1804"
       SWIFT_ZIP_FILE="ubuntu18.04"
       ;;
-    'Ubuntu:20.04' )
+    'ubuntu20.04' )
       SWIFT_BUILD_FOLDER="ubuntu2004"
       SWIFT_ZIP_FILE="ubuntu20.04"
       ;;
-    'CentOS Linux:7')
+    'centoslinux7')
       SWIFT_BUILD_FOLDER="centos7"
       SWIFT_ZIP_FILE="centos7"
       ;;
-    'CentOS Linux:8')
+    'centoslinux8')
       SWIFT_BUILD_FOLDER="centos8"
       SWIFT_ZIP_FILE="centos8"
       ;;
-    'Amazon Linux:2')
+    'amazonlinux2')
       SWIFT_BUILD_FOLDER="amazonlinux2"
       SWIFT_ZIP_FILE="amazonlinux2"
       ;;

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -55,18 +55,6 @@ get_platform() {
     OS_NAME=$(get_os_version_variable NAME)	  
     OS_VERSION_ID=$(get_os_version_variable VERSION_ID)
     echo "$OS_NAME:$OS_VERSION_ID"
-    #if command -v "lsb_release" >/dev/null 2>&1; then
-    #  if [ $(lsb_release -is) = "Ubuntu" ]; then
-    #    echo "ubuntu$(lsb_release -rs)"
-    #  elif [ $(lsb_release -ius) = "Ubuntu" ]; then
-    #    echo "ubuntu$(lsb_release -rus)"
-    #  else
-    #    echo "unsupported-platform"
-    #  fi
-    #elif [ -r "/etc/lsb-release" ]; then
-    #  echo "The `lsb_release` command line tool is missing. `/etc/lsb-release` file is found."
-    #  exit 1
-    #fi
     ;;
   'Darwin' )
     echo "osx"
@@ -205,7 +193,7 @@ build_version() {
 }
 
 find_binary_url_from_api() {
-  echo "Checking for a URL for Swift $VERSION on $(get_platform)."
+  vlog "Checking for a URL for Swift $VERSION on $(get_platform)."
 
   case $(get_platform) in
     'Ubuntu:16.04' )
@@ -235,26 +223,14 @@ find_binary_url_from_api() {
     'osx')
       url="https://swift.org/builds/swift-$VERSION-release/xcode/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-osx.pkg"
       return
+      ;;
     *)
       echo "There was a problem identifying your OS $(get_platform)"
-      exit 1  
+      exit 1
+      ;;
   esac
 
   url="https://swift.org/builds/swift-$VERSION-release/$SWIFT_BUILD_FOLDER/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$SWIFT_ZIP_FILE.tar.gz"
-
-  #status_code=$(curl -o /dev/null --silent --head --write-out '%{http_code}' "https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform)" || true)
-#
-#  if [ "$status_code" = "404" ]; then
-#    vlog "Did not find a binary release for $VERSION on $(get_platform)."
-#  elif [ "$status_code" = "200" ]; then
-#    url="$(curl --silent https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform) -H 'Accept: text/plain')"
-#  elif [ "$status_code" = "000" ]; then
-#    echo "There was a problem checking for a binary release of $VERSION, could not connect to the swiftenv API."
-#    exit 1
-#  else
-#    echo "There was a problem checking for a binary release of $VERSION, server returned $status_code."
-#    exit 1
-#  fi
 }
 
 sort_versions() {
@@ -432,7 +408,6 @@ if ([ "$build" == "auto" ] || [ "$build" == "false" ]); then
   fi
 
   if [ "$url" ]; then
-    echo "Installing $VERSION from $url on $(get_platform)."
     install_binary "$VERSION" "$url"
   elif [ "$build" == "false" ]; then
     echo "Could not find a binary release of $VERSION."

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -35,6 +35,10 @@ update_version_files() {
   fi
 }
 
+get_os_version_variable() {
+  grep "^$1=" /etc/os-release | cut -d "=" -f2 | tr -d '"'
+}
+
 get_platform() {
   if [ -n "$SWIFTENV_PLATFORM" ]; then
     echo "$SWIFTENV_PLATFORM"
@@ -48,18 +52,21 @@ get_platform() {
 
   case $(uname) in
   'Linux' )
-    if command -v "lsb_release" >/dev/null 2>&1; then
-      if [ $(lsb_release -is) = "Ubuntu" ]; then
-        echo "ubuntu$(lsb_release -rs)"
-      elif [ $(lsb_release -ius) = "Ubuntu" ]; then
-        echo "ubuntu$(lsb_release -rus)"
-      else
-        echo "unsupported-platform"
-      fi
-    elif [ -r "/etc/lsb-release" ]; then
-      echo "The `lsb_release` command line tool is missing. `/etc/lsb-release` file is found."
-      exit 1
-    fi
+    OS_NAME=$(get_os_version_variable NAME)	  
+    OS_VERSION_ID=$(get_os_version_variable VERSION_ID)
+    echo "$OS_NAME:$OS_VERSION_ID"
+    #if command -v "lsb_release" >/dev/null 2>&1; then
+    #  if [ $(lsb_release -is) = "Ubuntu" ]; then
+    #    echo "ubuntu$(lsb_release -rs)"
+    #  elif [ $(lsb_release -ius) = "Ubuntu" ]; then
+    #    echo "ubuntu$(lsb_release -rus)"
+    #  else
+    #    echo "unsupported-platform"
+    #  fi
+    #elif [ -r "/etc/lsb-release" ]; then
+    #  echo "The `lsb_release` command line tool is missing. `/etc/lsb-release` file is found."
+    #  exit 1
+    #fi
     ;;
   'Darwin' )
     echo "osx"
@@ -96,8 +103,13 @@ download() {
   local FILE
   URL=$1
   FILE=$2
-
+  
   if ! [ -r "$FILE" ]; then
+    status_code=$(curl -I -s -o /dev/null -w "%{http_code}" $URL || true)
+    if [ "$status_code" != "200" ]; then
+      echo "Cannot find file $URL"
+      exit 1
+    fi  
     curl -C - -Lo "$FILE.download" "$URL"
     mv "$FILE.download" "$FILE"
   fi
@@ -193,21 +205,56 @@ build_version() {
 }
 
 find_binary_url_from_api() {
-  vlog "Checking for a URL for the $VERSION on $(get_platform)."
+  echo "Checking for a URL for Swift $VERSION on $(get_platform)."
 
-  status_code=$(curl -o /dev/null --silent --head --write-out '%{http_code}' "https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform)" || true)
+  case $(get_platform) in
+    'Ubuntu:16.04' )
+      SWIFT_BUILD_FOLDER="ubuntu1604"
+      SWIFT_ZIP_FILE="ubuntu16.04"
+      ;;
+    'Ubuntu:18.04' )
+      SWIFT_BUILD_FOLDER="ubuntu1804"
+      SWIFT_ZIP_FILE="ubuntu18.04"
+      ;;
+    'Ubuntu:20.04' )
+      SWIFT_BUILD_FOLDER="ubuntu2004"
+      SWIFT_ZIP_FILE="ubuntu20.04"
+      ;;
+    'CentOS Linux:7')
+      SWIFT_BUILD_FOLDER="centos7"
+      SWIFT_ZIP_FILE="centos7"
+      ;;
+    'CentOS Linux:8')
+      SWIFT_BUILD_FOLDER="centos8"
+      SWIFT_ZIP_FILE="centos8"
+      ;;
+    'Amazon Linux:2')
+      SWIFT_BUILD_FOLDER="amazonlinux2"
+      SWIFT_ZIP_FILE="amazonlinux2"
+      ;;
+    'osx')
+      url="https://swift.org/builds/swift-$VERSION-release/xcode/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-osx.pkg"
+      return
+    *)
+      echo "There was a problem identifying your OS $(get_platform)"
+      exit 1  
+  esac
 
-  if [ "$status_code" = "404" ]; then
-    vlog "Did not find a binary release for $VERSION on $(get_platform)."
-  elif [ "$status_code" = "200" ]; then
-    url="$(curl --silent https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform) -H 'Accept: text/plain')"
-  elif [ "$status_code" = "000" ]; then
-    echo "There was a problem checking for a binary release of $VERSION, could not connect to the swiftenv API."
-    exit 1
-  else
-    echo "There was a problem checking for a binary release of $VERSION, server returned $status_code."
-    exit 1
-  fi
+  url="https://swift.org/builds/swift-$VERSION-release/$SWIFT_BUILD_FOLDER/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$SWIFT_ZIP_FILE.tar.gz"
+
+  #status_code=$(curl -o /dev/null --silent --head --write-out '%{http_code}' "https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform)" || true)
+#
+#  if [ "$status_code" = "404" ]; then
+#    vlog "Did not find a binary release for $VERSION on $(get_platform)."
+#  elif [ "$status_code" = "200" ]; then
+#    url="$(curl --silent https://swiftenv-api.fuller.li/versions/$VERSION/binaries/$(get_platform) -H 'Accept: text/plain')"
+#  elif [ "$status_code" = "000" ]; then
+#    echo "There was a problem checking for a binary release of $VERSION, could not connect to the swiftenv API."
+#    exit 1
+#  else
+#    echo "There was a problem checking for a binary release of $VERSION, server returned $status_code."
+#    exit 1
+#  fi
 }
 
 sort_versions() {
@@ -385,7 +432,7 @@ if ([ "$build" == "auto" ] || [ "$build" == "false" ]); then
   fi
 
   if [ "$url" ]; then
-    vlog "Installing $VERSION from $url on $(get_platform)."
+    echo "Installing $VERSION from $url on $(get_platform)."
     install_binary "$VERSION" "$url"
   elif [ "$build" == "false" ]; then
     echo "Could not find a binary release of $VERSION."

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -132,7 +132,13 @@ install_tar_binary() {
   popd
 
   DESTINATION="$SWIFTENV_ROOT/versions/$VERSION"
-  mv "$INSTALL_TMP/swift-$VERSION_RELEASE"*/ "$DESTINATION"
+  # Some archives don't have an enclosing directory so check "usr" exists first
+  if [ -d "$INSTALL_TMP/usr" ]; then
+    mkdir -p "$DESTINATION"
+    mv "$INSTALL_TMP/usr" "$DESTINATION"
+  else
+    mv "$INSTALL_TMP/swift-$VERSION_RELEASE"*/ "$DESTINATION"
+  fi
 
   if $clean; then
     rm -fr "$INSTALL_TMP"

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -407,14 +407,6 @@ fi
 # Install Binary
 if ([ "$build" == "auto" ] || [ "$build" == "false" ]); then
   if [ -z "$url" ]; then
-    # Check for locally cached URL
-    PROFILE="$SWIFTENV_SOURCE_PATH/share/swiftenv-install/$VERSION"
-    if [ -r "$PROFILE" ]; then
-      source "$PROFILE"
-    fi
-  fi
-
-  if [ -z "$url" ]; then
     find_binary_url_from_api
   fi
 

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -56,6 +56,14 @@ get_platform() {
   'Linux' )
     # lowercase OS_VERSION and remove spaces so get_platform is consistent with previous builds
     OS_VERSION=$(get_os_version | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+    # Is this aarch64
+    # Is this aarch64
+    if command -v "lscpu" >/dev/null 2>&1; then
+      CPU_ARCH=$(lscpu | grep Architecture | cut -d ":" -f2 | tr -d " ")
+      if [ "$CPU_ARCH" = "aarch64" ]; then
+        OS_VERSION="$OS_VERSION-aarch64"
+      fi
+    fi
     echo "$OS_VERSION"
     ;;
   'Darwin' )
@@ -203,9 +211,9 @@ find_binary_url_from_api() {
       SWIFT_ZIP_FILE=${platform/linux}
       EXTENSION="tar.gz"
       ;;
-    'amazonlinux2')
-      SWIFT_BUILD_FOLDER="amazonlinux2"
-      SWIFT_ZIP_FILE="amazonlinux2"
+    'amazonlinux2'*)
+      SWIFT_BUILD_FOLDER=$platform
+      SWIFT_ZIP_FILE=$platform
       EXTENSION="tar.gz"
       ;;
     'osx')

--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -55,7 +55,7 @@ get_platform() {
   case $(uname) in
   'Linux' )
     # lowercase OS_VERSION and remove spaces so get_platform is consistent with previous builds
-    OS_VERSION=$(get_os_version) | tr '[:upper:]' '[:lower:]' | tr -d ' '
+    OS_VERSION=$(get_os_version | tr '[:upper:]' '[:lower:]' | tr -d ' ')
     echo "$OS_VERSION"
     ;;
   'Darwin' )
@@ -93,7 +93,6 @@ download() {
   local FILE
   URL=$1
   FILE=$2
-  
   if ! [ -r "$FILE" ]; then
     status_code=$(curl -I -s -o /dev/null -w "%{http_code}" $URL || true)
     if [ "$status_code" != "200" ]; then
@@ -197,30 +196,15 @@ build_version() {
 find_binary_url_from_api() {
   vlog "Checking for a URL for Swift $VERSION on $(get_platform)."
 
-  case $(get_platform) in
-    'ubuntu14.04' )
-      SWIFT_BUILD_FOLDER="ubuntu1604"
-      SWIFT_ZIP_FILE="ubuntu14.04"
+  platform=$(get_platform)
+  case "$platform" in
+    'ubuntu'* )
+      SWIFT_BUILD_FOLDER=${platform/.}
+      SWIFT_ZIP_FILE=$platform
       ;;
-    'ubuntu16.04' )
-      SWIFT_BUILD_FOLDER="ubuntu1604"
-      SWIFT_ZIP_FILE="ubuntu16.04"
-      ;;
-    'ubuntu18.04' )
-      SWIFT_BUILD_FOLDER="ubuntu1804"
-      SWIFT_ZIP_FILE="ubuntu18.04"
-      ;;
-    'ubuntu20.04' )
-      SWIFT_BUILD_FOLDER="ubuntu2004"
-      SWIFT_ZIP_FILE="ubuntu20.04"
-      ;;
-    'centoslinux7')
-      SWIFT_BUILD_FOLDER="centos7"
-      SWIFT_ZIP_FILE="centos7"
-      ;;
-    'centoslinux8')
-      SWIFT_BUILD_FOLDER="centos8"
-      SWIFT_ZIP_FILE="centos8"
+    'centoslinux'* )
+      SWIFT_BUILD_FOLDER=${platform/linux}
+      SWIFT_ZIP_FILE=${platform/linux}
       ;;
     'amazonlinux2')
       SWIFT_BUILD_FOLDER="amazonlinux2"


### PR DESCRIPTION
To get this to work I had to make two changes
1) Instead of using `lsb_release` to identify which Linux we are running I parse the `/etc/os-release` file. This file is more likely to be available. 
2) I don't use ask `swiftenv-api.fuller.li` to get the URL for the swift release. The swift team have a standard naming scheme for swift releases so you should need to create a new entry for each new release of swift.

Closes #138, #172