### PR TITLE
Redirect 'swift --version' stderr to /dev/null

### DIFF
--- a/libexec/swiftenv-prefix
+++ b/libexec/swiftenv-prefix
@@ -49,7 +49,7 @@ if command -v "mdfind" >/dev/null 2>&1; then
   XCODES="$(mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null)"
   for xcode in $XCODES; do
     if [ -d "$xcode" ]; then
-      version_line="$(env DEVELOPER_DIR="$xcode" xcrun swift --version | head -n1)"
+      version_line="$(env DEVELOPER_DIR="$xcode" xcrun swift --version 2>/dev/null | head -n1)"
       version="swift-$(echo "$version_line" | cut -d " " -f 4)"
       if [ "$version" == "$SWIFT_VERSION" ] || [ "$version" == "swift-$SWIFT_VERSION" ]; then
         echo "$xcode/Contents/Developer/Toolchains/XcodeDefault.xctoolchain"


### PR DESCRIPTION
With the new swift driver running 'swift --version' will always print "swift-driver version: X.Y.Z" to stderr before printing the normal version info to stdout.
This causes all of the version checks as swiftenv runs to print the driver over and over.
The other option is to instead pass the flag '-disallow-use-new-driver' but at some point the new driver will most likely become the only driver so this future proofs against that.