### PR TITLE
Disable localization of `lscpu`.

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -214,7 +214,7 @@ find_binary_url_from_api() {
     # macOS uses dual architecture binaries
 
     if command -v "lscpu" >/dev/null 2>&1; then
-      cpu_arch=$(lscpu | grep Architecture | cut -d ":" -f2 | tr -d " ")
+      cpu_arch=$(LC_ALL=C lscpu | grep Architecture | cut -d ":" -f2 | tr -d " ")
       if [ "$cpu_arch" != "x86_64" ]; then
         architecture="-$cpu_arch"
       fi


### PR DESCRIPTION
The output of `lscpu` is localized. It means that `lscpu | grep Architecture` may return an empty result.

Resolves [#185](https://github.com/kylef/swiftenv/issues/185).