### PR TITLE
Use new URLs to download faster.

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -224,11 +224,11 @@ find_binary_url_from_api() {
   case "$VERSION" in
     *'-DEVELOPMENT-SNAPSHOT'* )
       VERSION_NUMBER=$(echo "$VERSION" | cut -d "-" -f1)
-      url="https://swift.org/builds/swift-$VERSION_NUMBER-branch/$platform_directory/swift-$VERSION/swift-$VERSION-$platform$architecture.$extension" ;;
+      url="https://download.swift.org/swift-$VERSION_NUMBER-branch/$platform_directory/swift-$VERSION/swift-$VERSION-$platform$architecture.$extension" ;;
     "DEVELOPMENT-SNAPSHOT"* )
-      url="https://swift.org/builds/development/$platform_directory/swift-$VERSION/swift-$VERSION-$platform$architecture.$extension" ;;
+      url="https://download.swift.org/development/$platform_directory/swift-$VERSION/swift-$VERSION-$platform$architecture.$extension" ;;
     * )
-      url="https://swift.org/builds/swift-$VERSION-release/$platform_directory/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$platform$architecture.$extension" ;;
+      url="https://download.swift.org/swift-$VERSION-release/$platform_directory/swift-$VERSION-RELEASE/swift-$VERSION-RELEASE-$platform$architecture.$extension" ;;
   esac
 
   vlog "Trying URL: $url"


### PR DESCRIPTION
Quote from https://forums.swift.org/t/faster-swift-downloads/52998

> Swift download links have moved to a new location to provide faster download speeds!
> The toolchains will be hosted at download.swift.org 9, and it will use a similar pattern as the current URL. 
> To use the new URL, replace swift.org/builds/ with download.swift.org/.