### PR TITLE
Fix URL for ARM64 Linux binaries

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -236,6 +236,7 @@ find_binary_url_from_api() {
       cpu_arch=$(LC_ALL=C lscpu | grep Architecture | cut -d ":" -f2 | tr -d " ")
       if [ "$cpu_arch" != "x86_64" ]; then
         architecture="-$cpu_arch"
+        platform_directory+="-$cpu_arch"
       fi
     fi
   fi


### PR DESCRIPTION
Fixes URL for ARM64 Linux binaries. Neither Windows or macOS binaries are affected.

---

Running `swiftenv install 5.7` on ARM64 Ubuntu results in:

```diff
- Downloading https://download.swift.org/swift-5.7-release/ubuntu2004/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu20.04-aarch64.tar.gz
+ Downloading https://download.swift.org/swift-5.7-release/ubuntu2004-aarch64/swift-5.7-RELEASE/swift-5.7-RELEASE-ubuntu20.04-aarch64.tar.gz
```

Which leads to successful installation.

<details><summary><h3>The problem</h3></summary>

Installing a version using `swiftenv 1.5.0` results in downloading a "Not found" web page instead of the binary, which then fails the installation:

```
/tmp/swiftenv-5.7- ~
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   304  100   304    0     0    387      0 --:--:-- --:--:-- --:--:--   386
100   257  100   257    0     0    276      0 --:--:-- --:--:-- --:--:--   276
100  7689  100  7689    0     0   4798      0  0:00:01  0:00:01 --:--:-- 7508k

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

</details>
