### PR TITLE
Actually verify tarball against PGP signature

### DIFF
--- a/libexec/swiftenv-install
+++ b/libexec/swiftenv-install
@@ -125,7 +125,7 @@ install_tar_binary() {
 
   if $verify; then
     curl -o "swift-$VERSION.sig" "$URL.sig"
-    gpg --verify "swift-$VERSION.sig"
+    gpg --verify "swift-$VERSION.sig" "swift-$VERSION.tar.gz"
   fi
 
   tar xzf "swift-$VERSION.tar.gz"


### PR DESCRIPTION
This addresses #192

With only this change, `gpg` logs a (slightly) more promising message:

```
gpg: Signature made Thu 30 Mar 2023 10:28:52 PM UTC using RSA key ID ED3D1561
gpg: Can't check signature: No public key
```

I understand that in https://github.com/kylef/swiftenv/pull/74 this is the desired result as it is intentional that swiftenv will not download the public keys. It would be nice if swiftenv did have a utility to help make that easier, but I agree it doesn't need to be part of the `install` command.

If I then get the Swift public keys as described on [Swift.org](https://www.swift.org/install/linux/#installation-via-tarball), we see a successful verification:

```
gpg: Signature made Mon 12 Sep 2022 07:39:56 AM UTC using RSA key ID ED3D1561
gpg: Good signature from "Swift 5.x Release Signing Key <swift-infrastructure@swift.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
```